### PR TITLE
Fix/#89

### DIFF
--- a/public/main.html
+++ b/public/main.html
@@ -41,6 +41,11 @@
           <div>
             <span id="close" class="material-symbols-outlined"> close </span>
           </div>
+          <div class="code-btn">
+            <button type="button" onclick="addCode(1)" class="material-symbols-outlined">
+              <span class="material-symbols code"> code </span>
+            </button>
+          </div>
           <div id="inputArea">
             <div class="box">
               <div class="title">

--- a/public/util.js
+++ b/public/util.js
@@ -243,7 +243,8 @@ export function editMemo(key) {
     console.log("editMemo",key);
     const title = document.getElementById("editTitle").value;
     const contents = document.getElementById("editContents").value;
-    const tags = splitTag(document.getElementById("editTags").value); 
+    const tags = splitTag(document.getElementById("editTags").value);
+    const popupWrapper = document.getElementById("popupEdit"); 
     // オブジェクト作成
     const memo = {
         "0":title,
@@ -260,4 +261,6 @@ export function editMemo(key) {
     
     // firestoreのドキュメントの上書き
     overWriteData(key,memo);
+
+    popupWrapper.style.display = "none";
 }


### PR DESCRIPTION
- 編集用ポップアップ内でeditボタンを押したときに、ポップアップが非表示になるように変更
- メモ作成画面で、コード追加用のボタンが表示されていなかったので追加