### PR TITLE
Bug/#99

### DIFF
--- a/public/main.html
+++ b/public/main.html
@@ -104,7 +104,7 @@
           <div id="inputArea">
             <div class="box">
               <div class="title show">
-                <h2 id="showTitle"></h2>
+                <p id="showTitle"></p>
               </div>
               <div class="content show">
                 <div id="contentsListArea" class="contentsList"></div>

--- a/public/style.css
+++ b/public/style.css
@@ -83,6 +83,7 @@ body {
 }
 
 .title.show {
+    overflow-wrap: break-word;
     border: 1px solid #00000062;
     border-radius: 10px 10px 10px 10px;
     padding: 5px;

--- a/public/style.css
+++ b/public/style.css
@@ -266,6 +266,9 @@ hr {
     top: 95px;
     text-align: center;
     pointer-events: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .create-btn {


### PR DESCRIPTION
- リストにメモが追加されるときにタイトルが長文だった場合、途中まで表示するように変更
- タイトルが長文だった場合、メモをクリックして表示したときにはみ出ないように途中で折り返すように変更